### PR TITLE
Add SPI types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ mod encode;
 mod meta;
 pub mod serial;
 mod settings;
+pub mod spi;
 mod stats;
 mod validators;
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,19 +1,28 @@
 use crate::encode::Encode;
 use serde::{Deserialize, Serialize};
 
+/// Request that the main chip sends to the IO chip.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum Request<'a> {
+    /// Start listening for messages.
     NetStart,
+    /// Stop accepting new messages and connections.
     NetStop,
+    /// Get MAC address of this device's IO chip.
     NetLocalAddr,
+    /// Broadcast advertisement message.
     NetAdvertise,
+    /// Read an incoming message (if any) from the IO chip.
     NetRecv,
-    NetSend(&'a [u8]),
+    /// Send an outgoing message to the IO chip.
+    NetSend([u8; 6], &'a [u8]),
+    /// Get the latest touchpad and buttons inputs.
     ReadInput,
 }
 
 impl<'a> Encode<'a> for Request<'a> {}
 
+/// Response that the IO chip sends back to the main chip.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum Response<'a> {
     NetError(u32),
@@ -21,7 +30,8 @@ pub enum Response<'a> {
     NetStopped,
     NetLocalAddr([u8; 6]),
     NetAdvertised,
-    NetIncoming(&'a [u8]),
+    NetIncoming([u8; 6], &'a [u8]),
+    NetNoIncoming,
     NetSent,
     Input(Option<(i16, i16)>, u8),
 }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,0 +1,29 @@
+use crate::encode::Encode;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub enum Request<'a> {
+    NetStart,
+    NetStop,
+    NetLocalAddr,
+    NetAdvertise,
+    NetRecv,
+    NetSend(&'a [u8]),
+    ReadInput,
+}
+
+impl<'a> Encode<'a> for Request<'a> {}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub enum Response<'a> {
+    NetError(u32),
+    NetStarted,
+    NetStopped,
+    NetLocalAddr([u8; 6]),
+    NetAdvertised,
+    NetIncoming(&'a [u8]),
+    NetSent,
+    Input(Option<(i16, i16)>, u8),
+}
+
+impl<'a> Encode<'a> for Response<'a> {}

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -34,6 +34,7 @@ pub enum Response<'a> {
     NetNoIncoming,
     NetSent,
     Input(Option<(i16, i16)>, u8),
+    PadError,
 }
 
 impl<'a> Encode<'a> for Response<'a> {}

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -25,7 +25,7 @@ impl<'a> Encode<'a> for Request<'a> {}
 /// Response that the IO chip sends back to the main chip.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum Response<'a> {
-    NetError(u32),
+    Error(&'a str),
     NetStarted,
     NetStopped,
     NetLocalAddr([u8; 6]),
@@ -34,7 +34,6 @@ pub enum Response<'a> {
     NetNoIncoming,
     NetSent,
     Input(Option<(i16, i16)>, u8),
-    PadError,
 }
 
 impl<'a> Encode<'a> for Response<'a> {}


### PR DESCRIPTION
The new SPI module contains request and response types that the chips on the actual device use to exchange messages.